### PR TITLE
fix: allow dynamic port configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
 const express = require("express");
 const os = require("os");
 const app = express();
-const PORT = 3000;
+// Allow the port to be configured via an environment variable so the
+// application can run in platforms where the port is assigned
+// dynamically (e.g. Docker, Heroku).
+const portFromEnv = parseInt(process.env.PORT, 10);
+const PORT = Number.isInteger(portFromEnv) ? portFromEnv : 3000;
 
 const ENV = process.env.NODE_ENV || "development";
 const getTimestamp = () => new Date().toLocaleString();
@@ -84,6 +88,7 @@ app.get("/health", (req, res) => {
   });
 });
 
-app.listen(PORT, "0.0.0.0", () =>
-  console.log(`Node app running on port ${PORT} in ${ENV} mode!`)
-);
+const server = app.listen(PORT, "0.0.0.0", () => {
+  const actualPort = server.address().port;
+  console.log(`Node app running on port ${actualPort} in ${ENV} mode!`);
+});


### PR DESCRIPTION
## Summary
- allow overriding the listening port via the `PORT` environment variable so the server works in dynamic environments
- log the actual bound port and validate `PORT` values

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af3e9c6cec83288ea71d9735f7da36